### PR TITLE
Add jackpot sound on reveal

### DIFF
--- a/index.html
+++ b/index.html
@@ -695,6 +695,31 @@
             oscillator.stop(audioContext.currentTime + 0.14);
           } catch (e) {}
         }
+
+        function playJackpotSound() {
+          try {
+            if (audioContext.state === "suspended") {
+              audioContext.resume();
+            }
+            const now = audioContext.currentTime;
+            const notes = [440, 523.25, 659.25, 784];
+            notes.forEach((freq, i) => {
+              const osc = audioContext.createOscillator();
+              const gain = audioContext.createGain();
+              osc.type = "square";
+              osc.frequency.setValueAtTime(freq, now + i * 0.15);
+              gain.gain.setValueAtTime(0.2, now + i * 0.15);
+              gain.gain.exponentialRampToValueAtTime(
+                0.001,
+                now + i * 0.15 + 0.3,
+              );
+              osc.connect(gain);
+              gain.connect(audioContext.destination);
+              osc.start(now + i * 0.15);
+              osc.stop(now + i * 0.15 + 0.3);
+            });
+          } catch (e) {}
+        }
         spinButton.addEventListener("mousedown", function () {
           this.classList.add("pressed");
           if (navigator.vibrate) navigator.vibrate(24);
@@ -850,6 +875,7 @@
 
         // ------------- REVEAL LOGIC -----------------
         function showReveal() {
+          playJackpotSound();
           const allLines = getRevealLinesFromParams(params);
           const mainLine = allLines.find((l) => l.type === "main");
           const otherLines = allLines.filter((l) => l.type !== "main");


### PR DESCRIPTION
## Summary
- add simple `playJackpotSound` Web Audio routine
- trigger jackpot sound when the reels align and the reveal overlay shows

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6876b1596010832f87541c97c36f861f